### PR TITLE
add script to download data and brush up rural status reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # mua_app
 
+Reports if a lat/lon coordinate is in a medically underserved area, as defined by the [Health Resources & Services Administration(https://data.hrsa.gov/data/download)]. If in an underserved area, it also reports if the area is considered rural.
+
 Examples:
 
 | **Name** |  **Latitude** | **Longitude** | **Results** | 

--- a/app.R
+++ b/app.R
@@ -18,7 +18,7 @@ ui <- fluidPage(
     sidebarLayout(
         sidebarPanel(
             h4("First geocode the address to obtain the latitude and longitude."),
-            a("Click here to use the online geocoder provided by Texas A&M.", href="http://geoservices.tamu.edu/Services/Geocode/Interactive/"),
+          a("Click here to use the online geocoder provided by Texas A&M.", href="http://geoservices.tamu.edu/Services/Geocode/Interactive/", target = "_blank"),
             br(),
             h4("Then copy and paste the latitude and longitude below."),
             # textInput("street", label = h3("Street Address"), value = "Enter text..."),

--- a/app.R
+++ b/app.R
@@ -65,18 +65,18 @@ server <- function(input, output) {
     overlay <- reactive({
         x <- st_join(coords_pt(), mua_crop(), left = FALSE, largest=TRUE)
         if (nrow(x) > 0) {return(x)}
-        else return(data.frame(RurStatDes = NA))
+        else return(data.frame(rural_status = 'Not applicable'))
     })
 
     output$mua <- renderText({
-        if(is.na(overlay()$RurStatDes)) {
-            "Medically Underserved Area: No."
+        if(is.na(overlay()$rural_status)) {
+            "Medically Underserved Area: No"
         }
         else "Medically Underserved Area: Yes"
     })
     
     output$rural <- renderText({
-        paste0("Rural Status: ", as.character(overlay()$RurStatDes))
+        paste0("Rural Status: ", as.character(overlay()$rural_status))
     })
     
     output$map <- leaflet::renderLeaflet({

--- a/app.R
+++ b/app.R
@@ -69,7 +69,7 @@ server <- function(input, output) {
     })
 
     output$mua <- renderText({
-        if(is.na(overlay()$rural_status)) {
+        if(overlay()$rural_status == 'Not applicable') {
             "Medically Underserved Area: No"
         }
         else "Medically Underserved Area: Yes"

--- a/make_app_data.R
+++ b/make_app_data.R
@@ -1,0 +1,14 @@
+library(tidyverse)
+library(sf)
+
+temp <- tempfile()
+download.file('https://data.hrsa.gov//DataDownload/DD_Files/MUA_SHP.zip', temp)
+unzip(temp, exdir = './MUA_SHP/')
+d <- read_sf('MUA_SHP/MUA_SHP_DET_CUR_VX.shp')
+unlink(temp)
+unlink('./MUA_SHP/', recursive = TRUE)
+d <- sf::st_transform(d, 5072)
+
+d %>%
+  select(rural_status = RurStatDes) %>%
+  saveRDS('mua_shp_5072.rds')


### PR DESCRIPTION
- use file for downloading, unzipping, and saving shapefile
- keeps only the appropriate rural status column and names it `rural_status`
- reports `Not applicable` instead of `NA` for rural status if point is not in MUA
- ensures link to AnM geocoder is opened in a new tab